### PR TITLE
Updating Readme.md to include docker download link

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -8,3 +8,6 @@ manpages/
 dist/
 completions/
 .go
+
+# for Intellij PyCharm IDE
+/.idea/

--- a/README.md
+++ b/README.md
@@ -16,6 +16,8 @@ CLI app and daemon for managing bitswan automation server and workspace deployme
 <!--ts-->
    * [bitswan-workspaces](#bitswan-workspaces)
    * [Features](#features)
+   * [Prerequisites](#prerequisites)
+   * [Installation](#installation) 
    * [Contribute](#contribute)
 
 <!--te-->
@@ -24,6 +26,13 @@ CLI app and daemon for managing bitswan automation server and workspace deployme
 - Automatically set up independent bitswan workspaces deployments.
 - Deployments can either connect to the bitswan.space SaaS, use the on prem bitswan management tools or operate completely independently
 
+
+Prerequisites
+--------------
+Before installation, make sure you have installed `Docker` and `Docker compose`. Installation guides can be found on these links :
+
+- [Docker](https://docs.docker.com/engine/install/)
+- [Docker compose](https://docs.docker.com/compose/install/)
 
 # Installation
 ## Linux / WSL


### PR DESCRIPTION
Resolves #191 
- Adding README to include information on how to download Docker and Docker compose. `mkcert` part was already mention within the documentation.
- I also updated `.gitignore` to include dev files from PyCharm