### PR TITLE
added oauthproxy

### DIFF
--- a/README.md
+++ b/README.md
@@ -108,6 +108,20 @@ You can get the password to the editor using the command:
 bitswan workspace list --long --passwords
 ```
 
+You can put an editor behind a proxy like this
+
+```sh
+bitswan workspace init dev-workspace \
+  --domain bitswan.localhost \
+  --oauth-issuer-url "<your-oauth-issuer-url>/realms/<yourrealm>" \
+  --oauth-client-id "<your-oauth=client-id>" \
+  --oauth-client-secret "<your-client-secret>" \
+  --oauth-cookie-secret "<your-cookie-secret>" \
+  --oauth-email-domains "<you can use * to allow all domains>" \ 
+  --oauth-allowed-groups "<your-allowed-groups>" \
+```
+
+
 ## Remote git repository
 
 If you wanna connect and persist your pipelines and GitOps configuration in remote git repository you can use `--remote` flag to specify your repository. `main` branch will be used to store pipelines code and each workspace will create it's own branch (e.g. `my-workspace`) to store their configurations.

--- a/README.md
+++ b/README.md
@@ -111,14 +111,18 @@ bitswan workspace list --long --passwords
 You can put an editor behind a proxy like this
 
 ```sh
-bitswan workspace init dev-workspace \
-  --domain bitswan.localhost \
-  --oauth-issuer-url "<your-oauth-issuer-url>/realms/<yourrealm>" \
-  --oauth-client-id "<your-oauth=client-id>" \
-  --oauth-client-secret "<your-client-secret>" \
-  --oauth-cookie-secret "<your-cookie-secret>" \
-  --oauth-email-domains "<you can use * to allow all domains>" \ 
-  --oauth-allowed-groups "<your-allowed-groups>" \
+bitswan workspace init --domain=bitswan.localhost --mkcerts dev-workspace --oauth-config <json-file>
+```
+Example of json file
+```json
+{
+  "oauth_issuer_url": "<your-oauth-issuer-url>/realms/<yourrealm>",
+  "oauth_client_id": "<your-oauth=client-id>",
+  "oauth_client_secret": "<your-client-secret>",
+  "oauth_cookie_secret": "<your-cookie-secret>",
+  "oauth_email_domains": ["<you can use * to allow all domains>"],
+  "oauth_allowed_groups": ["<your-allowed-groups>"]
+}
 ```
 
 

--- a/README.md
+++ b/README.md
@@ -108,7 +108,7 @@ You can get the password to the editor using the command:
 bitswan workspace list --long --passwords
 ```
 
-You can put an editor behind a proxy like this
+You can use an OAuth2 authentication to access the editor
 
 ```sh
 bitswan workspace init --domain=bitswan.localhost --mkcerts dev-workspace --oauth-config <json-file>

--- a/cmd/update.go
+++ b/cmd/update.go
@@ -150,12 +150,10 @@ func updateGitops(workspaceName string, o *updateOptions) error {
 	}
 
 
-	oauthConfig := oauth.GetOauthConfig(workspaceName)
-	if(oauthConfig == nil) {
-		fmt.Println("No OAuth config found, skipping...")
-		} else {
-			fmt.Println("OAuth config found")
-		}		
+	oauthConfig, err := oauth.GetOauthConfig(workspaceName)
+	if err != nil {
+		return fmt.Errorf("failed to get OAuth config: %w", err)
+	}
 		
 	// Rewrite the docker-compose file
 	noIde := metadata.EditorURL == nil

--- a/cmd/update.go
+++ b/cmd/update.go
@@ -12,6 +12,7 @@ import (
 	"gopkg.in/yaml.v3"
 
 	"github.com/bitswan-space/bitswan-workspaces/internal/dockercompose"
+	"github.com/bitswan-space/bitswan-workspaces/internal/oauth"
 	"github.com/bitswan-space/bitswan-workspaces/internal/dockerhub"
 	"github.com/spf13/cobra"
 )
@@ -148,9 +149,17 @@ func updateGitops(workspaceName string, o *updateOptions) error {
 		aocEnvVars = append(aocEnvVars, "BITSWAN_AOC_TOKEN="+automationServerTokenResponse.Token)
 	}
 
+
+	oauthConfig := oauth.GetOauthConfig(workspaceName)
+	if(oauthConfig == nil) {
+		fmt.Println("No OAuth config found, skipping...")
+		} else {
+			fmt.Println("OAuth config found")
+		}		
+		
 	// Rewrite the docker-compose file
 	noIde := metadata.EditorURL == nil
-	compose, _, err := dockercompose.CreateDockerComposeFile(gitopsConfig, workspaceName, gitopsImage, bitswanEditorImage, metadata.Domain, noIde, mqttEnvVars, aocEnvVars)
+	compose, _, err := dockercompose.CreateDockerComposeFile(gitopsConfig, workspaceName, gitopsImage, bitswanEditorImage, metadata.Domain, noIde, mqttEnvVars, aocEnvVars, oauthConfig)
 	if err != nil {
 		panic(fmt.Errorf("failed to create docker-compose file: %w", err))
 	}

--- a/internal/dockercompose/dockercompose.go
+++ b/internal/dockercompose/dockercompose.go
@@ -131,7 +131,7 @@ func CreateDockerComposeFile(gitopsPath, workspaceName, gitopsImage, bitswanEdit
 			},
 		}
 
-		if oauthConfig != nil && oauthConfig.Enabled {
+		if oauthConfig != nil {
 			oauthEnvVars := []string{
 				"OAUTH_ENABLED=true", // This is the trigger entrypoint script
 				"OAUTH2_PROXY_PROVIDER=keycloak-oidc",

--- a/internal/oauth/config.go
+++ b/internal/oauth/config.go
@@ -1,0 +1,62 @@
+package oauth
+
+import (
+	"fmt"
+	"os"
+
+	"gopkg.in/yaml.v2"
+)
+
+type Config struct {
+	Enabled       bool
+	ClientId      string
+	ClientSecret  string
+	IssuerUrl     string
+	RedirectUrl   string
+	Scopes        string
+	CookieSecret  string
+	EmailDomains  []string
+	AllowedGroups []string
+}
+
+func GetOauthConfig(workspaceName string) *Config {
+	var config Config
+	fmt.Println("Getting OAuth config for workspace:", workspaceName)
+	workspacePath := os.Getenv("HOME") + "/.config/bitswan/workspaces/" + workspaceName 
+	configPath := workspacePath + "/secrets/oauth-config.yaml"
+
+	if _, err := os.Stat(configPath); os.IsNotExist(err) {	
+		fmt.Println("No OAuth config found, skipping...")
+		return nil
+	}
+
+	fmt.Println("Config path:", configPath)
+
+	fileContent, err := os.ReadFile(configPath)
+	if err != nil {
+		fmt.Println("Error reading OAuth config file:", err)
+		return nil
+	}
+
+	if err := yaml.Unmarshal(fileContent, &config); err != nil {
+		fmt.Println("Error unmarshalling OAuth config file:", err)
+		return nil
+	}
+
+	requiredFields := map[string]string{
+		"client_id":     config.ClientId,
+		"client_secret": config.ClientSecret,
+		"issuer_url":    config.IssuerUrl,
+		"cookie_secret": config.CookieSecret,
+	}
+
+	for field, value := range requiredFields {
+		if value == "" {
+			fmt.Printf("Error: %s is required\n", field)
+			return nil
+		}
+	}
+
+	return &config
+}
+

--- a/internal/oauth/config.go
+++ b/internal/oauth/config.go
@@ -1,6 +1,7 @@
 package oauth
 
 import (
+	"encoding/json"
 	"fmt"
 	"os"
 
@@ -8,18 +9,16 @@ import (
 )
 
 type Config struct {
-	Enabled       bool
-	ClientId      string
-	ClientSecret  string
-	IssuerUrl     string
-	RedirectUrl   string
-	Scopes        string
-	CookieSecret  string
-	EmailDomains  []string
-	AllowedGroups []string
+	ClientId      string `json:"client_id"`
+	ClientSecret  string `json:"client_secret"`
+	IssuerUrl     string `json:"issuer_url"`
+	RedirectUrl   string `json:"redirect_url"`
+	CookieSecret  string `json:"cookie_secret"`
+	EmailDomains  []string `json:"email_domains"`
+	AllowedGroups []string `json:"allowed_groups"`
 }
 
-func GetOauthConfig(workspaceName string) *Config {
+func GetOauthConfig(workspaceName string) (*Config, error) {
 	var config Config
 	fmt.Println("Getting OAuth config for workspace:", workspaceName)
 	workspacePath := os.Getenv("HOME") + "/.config/bitswan/workspaces/" + workspaceName 
@@ -27,7 +26,7 @@ func GetOauthConfig(workspaceName string) *Config {
 
 	if _, err := os.Stat(configPath); os.IsNotExist(err) {	
 		fmt.Println("No OAuth config found, skipping...")
-		return nil
+		return nil, fmt.Errorf("no OAuth config found")
 	}
 
 	fmt.Println("Config path:", configPath)
@@ -35,28 +34,41 @@ func GetOauthConfig(workspaceName string) *Config {
 	fileContent, err := os.ReadFile(configPath)
 	if err != nil {
 		fmt.Println("Error reading OAuth config file:", err)
-		return nil
+		return nil, fmt.Errorf("error reading OAuth config file: %w", err)
 	}
 
 	if err := yaml.Unmarshal(fileContent, &config); err != nil {
 		fmt.Println("Error unmarshalling OAuth config file:", err)
-		return nil
+		return nil, fmt.Errorf("error unmarshalling OAuth config file: %w", err)
 	}
 
-	requiredFields := map[string]string{
-		"client_id":     config.ClientId,
-		"client_secret": config.ClientSecret,
-		"issuer_url":    config.IssuerUrl,
-		"cookie_secret": config.CookieSecret,
+	if config.ClientId == "" || config.ClientSecret == "" || config.IssuerUrl == "" || config.CookieSecret == "" {
+		fmt.Println("Error: all required fields are not set")
+		return nil, fmt.Errorf("all required fields are not set")
 	}
 
-	for field, value := range requiredFields {
-		if value == "" {
-			fmt.Printf("Error: %s is required\n", field)
-			return nil
-		}
-	}
-
-	return &config
+	return &config, nil
 }
 
+func GetInitOauthConfig(oauthConfigFile string) (*Config, error) {
+	var config Config
+
+	// Read the JSON file
+	jsonFile, err := os.Open(oauthConfigFile)
+	if err != nil {
+		return nil, fmt.Errorf("error opening OAuth config file: %w", err)
+	}
+	defer jsonFile.Close()
+
+	// Parse the JSON file
+	if err := json.NewDecoder(jsonFile).Decode(&config); err != nil {
+		return nil, fmt.Errorf("invalid JSON file: %w", err)
+	}
+
+	// Check if all required fields are set
+	if config.ClientId == "" || config.ClientSecret == "" || config.IssuerUrl == "" || config.CookieSecret == "" {
+		return nil, fmt.Errorf("all required fields are not set")
+	}
+
+	return &config, nil
+}


### PR DESCRIPTION
This pull request introduces OAuth proxy support for Bitswan workspaces, allowing users to secure their editor behind an OAuth-enabled proxy. The changes add new command-line flags for OAuth configuration, update the workspace initialization and update flows to handle OAuth, and propagate the settings through the Docker Compose setup. Additionally, a new module is introduced to manage OAuth configuration files.

**OAuth Proxy Integration**

* Added new flags to the `init` command for OAuth proxy configuration, including issuer URL, client ID, client secret, cookie secret, allowed email domains, and allowed groups. These are now part of the `initOptions` struct and CLI flags. [[1]](diffhunk://#diff-345cd3beb7d905a8bef99d83e99c62678bfd5101a26d30104ecc9320602072acR40-R46) [[2]](diffhunk://#diff-345cd3beb7d905a8bef99d83e99c62678bfd5101a26d30104ecc9320602072acR97-R103)
* During workspace initialization, if OAuth is enabled, the configuration is validated, marshaled to YAML, and saved to the workspace secrets directory. The OAuth settings are passed to the Docker Compose generator and used to set environment variables for the editor service. [[1]](diffhunk://#diff-345cd3beb7d905a8bef99d83e99c62678bfd5101a26d30104ecc9320602072acR437-R457) [[2]](diffhunk://#diff-345cd3beb7d905a8bef99d83e99c62678bfd5101a26d30104ecc9320602072acR636-R646) [[3]](diffhunk://#diff-345cd3beb7d905a8bef99d83e99c62678bfd5101a26d30104ecc9320602072acR860) [[4]](diffhunk://#diff-2f9a2ff80632e64faeb11875049583b12161ce10cb3bf885e7d524bdd0dea181L26-R27) [[5]](diffhunk://#diff-2f9a2ff80632e64faeb11875049583b12161ce10cb3bf885e7d524bdd0dea181R134-R157)
* On workspace update, the OAuth configuration is loaded from the secrets directory and applied to the Docker Compose file if present.
* Added a new `internal/oauth/config.go` module to encapsulate reading and validating OAuth configuration files for workspaces.

**Documentation**

* Updated `README.md` with instructions and example CLI usage for initializing a workspace with OAuth proxy support.

These changes make it possible to secure the Bitswan editor with OAuth, improving security and access control for workspace environments.
[Copilot is generating a summary...]