### PR TITLE
Ingress management

### DIFF
--- a/cmd/caddy/init.go
+++ b/cmd/caddy/init.go
@@ -1,16 +1,10 @@
 package caddy
 
 import (
-	"bytes"
 	"fmt"
-	"io"
 	"os"
-	"os/exec"
-	"sync"
-	"time"
 
-	"github.com/bitswan-space/bitswan-workspaces/internal/caddyapi"
-	"github.com/bitswan-space/bitswan-workspaces/internal/dockercompose"
+	"github.com/bitswan-space/bitswan-workspaces/cmd/ingress"
 	"github.com/spf13/cobra"
 )
 
@@ -23,7 +17,9 @@ func newInitCmd() *cobra.Command {
 		Short: "Initializes a Caddy",
 		Args:  cobra.NoArgs,
 		RunE: func(cmd *cobra.Command, args []string) error {
-			if err := InitCaddy(domain, verbose); err != nil {
+			// Print deprecation warning to STDERR
+			fmt.Fprintln(os.Stderr, "WARNING: The 'caddy init' command is deprecated and will be removed in a future version. Please use 'ingress init' instead.")
+			if err := ingress.InitIngress(domain, verbose); err != nil {
 				return fmt.Errorf("failed to initialize Caddy: %w", err)
 			}
 			return nil
@@ -38,140 +34,4 @@ func newInitCmd() *cobra.Command {
 	return cmd
 }
 
-func runCommandVerbose(cmd *exec.Cmd, verbose bool) error {
-	var stdoutBuf, stderrBuf bytes.Buffer
 
-	if verbose {
-		// Set up pipes for real-time streaming
-		stdoutPipe, err := cmd.StdoutPipe()
-		if err != nil {
-			return fmt.Errorf("failed to create stdout pipe: %w", err)
-		}
-
-		stderrPipe, err := cmd.StderrPipe()
-		if err != nil {
-			return fmt.Errorf("failed to create stderr pipe: %w", err)
-		}
-
-		// Create multi-writers to both stream and capture output
-		stdoutWriter := io.MultiWriter(os.Stdout, &stdoutBuf)
-		stderrWriter := io.MultiWriter(os.Stderr, &stderrBuf)
-
-		// Start the command
-		if err := cmd.Start(); err != nil {
-			return fmt.Errorf("failed to start command: %w", err)
-		}
-
-		// Copy stdout and stderr in separate goroutines
-		var wg sync.WaitGroup
-		wg.Add(2)
-
-		go func() {
-			defer wg.Done()
-			io.Copy(stdoutWriter, stdoutPipe)
-		}()
-
-		go func() {
-			defer wg.Done()
-			io.Copy(stderrWriter, stderrPipe)
-		}()
-
-		// Wait for all output to be processed
-		wg.Wait()
-
-		// Wait for command to complete
-		err = cmd.Wait()
-		return err
-	} else {
-		// Not verbose, just capture output for potential error reporting
-		cmd.Stdout = &stdoutBuf
-		cmd.Stderr = &stderrBuf
-
-		err := cmd.Run()
-
-		// If command failed, print the captured output
-		if err != nil {
-			if stdoutBuf.Len() > 0 {
-				fmt.Println("Command stdout:")
-				fmt.Println(stdoutBuf.String())
-			}
-
-			if stderrBuf.Len() > 0 {
-				fmt.Println("Command stderr:")
-				fmt.Println(stderrBuf.String())
-			}
-		}
-
-		return err
-	}
-}
-
-func InitCaddy(domain string, verbose bool) error {
-	bitswanConfig := os.Getenv("HOME") + "/.config/bitswan/"
-	caddyConfig := bitswanConfig + "caddy"
-	caddyCertsDir := caddyConfig + "/certs"
-
-	fmt.Println("Setting up Caddy...")
-	if err := os.MkdirAll(caddyConfig, 0755); err != nil {
-		return fmt.Errorf("failed to create Caddy config directory: %w", err)
-	}
-
-	// Create Caddyfile with email and modify admin listener
-	caddyfile := `
-		{
-			email info@bitswan.space
-			admin 0.0.0.0:2019
-		}`
-
-	caddyfilePath := caddyConfig + "/Caddyfile"
-	if err := os.WriteFile(caddyfilePath, []byte(caddyfile), 0755); err != nil {
-		panic(fmt.Errorf("failed to write Caddyfile: %w", err))
-	}
-
-	caddyDockerCompose, err := dockercompose.CreateCaddyDockerComposeFile(caddyConfig, domain)
-	if err != nil {
-		panic(fmt.Errorf("failed to create Caddy docker-compose file: %w", err))
-	}
-
-	caddyDockerComposePath := caddyConfig + "/docker-compose.yml"
-	if err := os.WriteFile(caddyDockerComposePath, []byte(caddyDockerCompose), 0755); err != nil {
-		panic(fmt.Errorf("failed to write Caddy docker-compose file: %w", err))
-	}
-
-	err = os.Chdir(caddyConfig)
-	if err != nil {
-		panic(fmt.Errorf("failed to change directory to Caddy config: %w", err))
-	}
-
-	caddyProjectName := "bitswan-caddy"
-	caddyDockerComposeCom := exec.Command("docker", "compose", "-p", caddyProjectName, "up", "-d")
-
-	// Capture both stdout and stderr
-	var stdout, stderr bytes.Buffer
-	caddyDockerComposeCom.Stdout = &stdout
-	caddyDockerComposeCom.Stderr = &stderr
-
-	// Create certs directory if it doesn't exist
-	if _, err := os.Stat(caddyCertsDir); os.IsNotExist(err) {
-		if err := os.MkdirAll(caddyCertsDir, 0740); err != nil {
-			return fmt.Errorf("failed to create Caddy certs directory: %w", err)
-		}
-	}
-
-	fmt.Println("Starting Caddy...")
-	if err := runCommandVerbose(caddyDockerComposeCom, verbose); err != nil {
-		// Combine stdout and stderr for complete output
-		fullOutput := stdout.String() + stderr.String()
-		return fmt.Errorf("failed to start Caddy:\nError: %v\nOutput:\n%s", err, fullOutput)
-	}
-
-	// wait 5s to make sure Caddy is up
-	time.Sleep(5 * time.Second)
-	err = caddyapi.InitCaddy()
-	if err != nil {
-		panic(fmt.Errorf("failed to init Caddy: %w", err))
-	}
-
-	fmt.Println("Caddy started successfully!")
-	return nil
-}

--- a/cmd/caddy/init.go
+++ b/cmd/caddy/init.go
@@ -9,7 +9,6 @@ import (
 )
 
 func newInitCmd() *cobra.Command {
-	var domain string
 	var verbose bool
 
 	cmd := &cobra.Command{
@@ -19,17 +18,14 @@ func newInitCmd() *cobra.Command {
 		RunE: func(cmd *cobra.Command, args []string) error {
 			// Print deprecation warning to STDERR
 			fmt.Fprintln(os.Stderr, "WARNING: The 'caddy init' command is deprecated and will be removed in a future version. Please use 'ingress init' instead.")
-			if err := ingress.InitIngress(domain, verbose); err != nil {
+			if err := ingress.InitIngress(verbose); err != nil {
 				return fmt.Errorf("failed to initialize Caddy: %w", err)
 			}
 			return nil
 		},
 	}
 
-	cmd.Flags().StringVar(&domain, "domain", "", "The domain to use for the Caddyfile")
 	cmd.Flags().BoolVarP(&verbose, "verbose", "v", false, "Enable verbose output")
-
-	cmd.MarkFlagRequired("domain")
 
 	return cmd
 }

--- a/cmd/caddy/root.go
+++ b/cmd/caddy/root.go
@@ -1,12 +1,19 @@
 package caddy
 
-import "github.com/spf13/cobra"
+import (
+	"fmt"
+	"os"
+
+	"github.com/spf13/cobra"
+)
 
 func NewCaddyCmd() *cobra.Command {
 	cmd := &cobra.Command{
 		Use:   "caddy",
 		Short: "Manage caddy",
 		RunE: func(cmd *cobra.Command, args []string) error {
+			// Print deprecation warning to STDERR
+			fmt.Fprintln(os.Stderr, "WARNING: The 'caddy' command is deprecated and will be removed in a future version. Please use 'ingress' instead.")
 			return cmd.Help()
 		},
 	}

--- a/cmd/ingress/add_route.go
+++ b/cmd/ingress/add_route.go
@@ -1,0 +1,32 @@
+package ingress
+
+import (
+	"fmt"
+
+	"github.com/bitswan-space/bitswan-workspaces/internal/caddyapi"
+	"github.com/spf13/cobra"
+)
+
+func newAddRouteCmd() *cobra.Command {
+	cmd := &cobra.Command{
+		Use:   "add-route <hostname> <upstream>",
+		Short: "Add a route mapping hostname to upstream",
+		Long: `Add a route that maps a hostname to an upstream server.
+
+Examples:
+  bitswan ingress add-route foo.bar.example.com internal-host-name:2904
+  bitswan ingress add-route api.myapp.com localhost:8080`,
+		Args: cobra.ExactArgs(2),
+		RunE: func(cmd *cobra.Command, args []string) error {
+			hostname := args[0]
+			upstream := args[1]
+
+			if err := caddyapi.AddRoute(hostname, upstream); err != nil {
+				return fmt.Errorf("failed to add route: %w", err)
+			}
+			return nil
+		},
+	}
+
+	return cmd
+} 

--- a/cmd/ingress/init.go
+++ b/cmd/ingress/init.go
@@ -1,0 +1,177 @@
+package ingress
+
+import (
+	"bytes"
+	"fmt"
+	"io"
+	"os"
+	"os/exec"
+	"sync"
+	"time"
+
+	"github.com/bitswan-space/bitswan-workspaces/internal/caddyapi"
+	"github.com/bitswan-space/bitswan-workspaces/internal/dockercompose"
+	"github.com/spf13/cobra"
+)
+
+func newInitCmd() *cobra.Command {
+	var domain string
+	var verbose bool
+
+	cmd := &cobra.Command{
+		Use:   "init",
+		Short: "Initializes an ingress proxy",
+		Args:  cobra.NoArgs,
+		RunE: func(cmd *cobra.Command, args []string) error {
+			if err := InitIngress(domain, verbose); err != nil {
+				return fmt.Errorf("failed to initialize ingress: %w", err)
+			}
+			return nil
+		},
+	}
+
+	cmd.Flags().StringVar(&domain, "domain", "", "The domain to use for the ingress configuration")
+	cmd.Flags().BoolVarP(&verbose, "verbose", "v", false, "Enable verbose output")
+
+	cmd.MarkFlagRequired("domain")
+
+	return cmd
+}
+
+func runCommandVerbose(cmd *exec.Cmd, verbose bool) error {
+	var stdoutBuf, stderrBuf bytes.Buffer
+
+	if verbose {
+		// Set up pipes for real-time streaming
+		stdoutPipe, err := cmd.StdoutPipe()
+		if err != nil {
+			return fmt.Errorf("failed to create stdout pipe: %w", err)
+		}
+
+		stderrPipe, err := cmd.StderrPipe()
+		if err != nil {
+			return fmt.Errorf("failed to create stderr pipe: %w", err)
+		}
+
+		// Create multi-writers to both stream and capture output
+		stdoutWriter := io.MultiWriter(os.Stdout, &stdoutBuf)
+		stderrWriter := io.MultiWriter(os.Stderr, &stderrBuf)
+
+		// Start the command
+		if err := cmd.Start(); err != nil {
+			return fmt.Errorf("failed to start command: %w", err)
+		}
+
+		// Copy stdout and stderr in separate goroutines
+		var wg sync.WaitGroup
+		wg.Add(2)
+
+		go func() {
+			defer wg.Done()
+			io.Copy(stdoutWriter, stdoutPipe)
+		}()
+
+		go func() {
+			defer wg.Done()
+			io.Copy(stderrWriter, stderrPipe)
+		}()
+
+		// Wait for all output to be processed
+		wg.Wait()
+
+		// Wait for command to complete
+		err = cmd.Wait()
+		return err
+	} else {
+		// Not verbose, just capture output for potential error reporting
+		cmd.Stdout = &stdoutBuf
+		cmd.Stderr = &stderrBuf
+
+		err := cmd.Run()
+
+		// If command failed, print the captured output
+		if err != nil {
+			if stdoutBuf.Len() > 0 {
+				fmt.Println("Command stdout:")
+				fmt.Println(stdoutBuf.String())
+			}
+
+			if stderrBuf.Len() > 0 {
+				fmt.Println("Command stderr:")
+				fmt.Println(stderrBuf.String())
+			}
+		}
+
+		return err
+	}
+}
+
+func InitIngress(domain string, verbose bool) error {
+	bitswanConfig := os.Getenv("HOME") + "/.config/bitswan/"
+	caddyConfig := bitswanConfig + "caddy"
+	caddyCertsDir := caddyConfig + "/certs"
+
+	fmt.Println("Setting up ingress proxy...")
+	if err := os.MkdirAll(caddyConfig, 0755); err != nil {
+		return fmt.Errorf("failed to create ingress config directory: %w", err)
+	}
+
+	// Create Caddyfile with email and modify admin listener
+	caddyfile := `
+		{
+			email info@bitswan.space
+			admin 0.0.0.0:2019
+		}`
+
+	caddyfilePath := caddyConfig + "/Caddyfile"
+	if err := os.WriteFile(caddyfilePath, []byte(caddyfile), 0755); err != nil {
+		panic(fmt.Errorf("failed to write Caddyfile: %w", err))
+	}
+
+	caddyDockerCompose, err := dockercompose.CreateCaddyDockerComposeFile(caddyConfig, domain)
+	if err != nil {
+		panic(fmt.Errorf("failed to create ingress docker-compose file: %w", err))
+	}
+
+	caddyDockerComposePath := caddyConfig + "/docker-compose.yml"
+	if err := os.WriteFile(caddyDockerComposePath, []byte(caddyDockerCompose), 0755); err != nil {
+		panic(fmt.Errorf("failed to write ingress docker-compose file: %w", err))
+	}
+
+	err = os.Chdir(caddyConfig)
+	if err != nil {
+		panic(fmt.Errorf("failed to change directory to ingress config: %w", err))
+	}
+
+	caddyProjectName := "bitswan-caddy"
+	caddyDockerComposeCom := exec.Command("docker", "compose", "-p", caddyProjectName, "up", "-d")
+
+	// Capture both stdout and stderr
+	var stdout, stderr bytes.Buffer
+	caddyDockerComposeCom.Stdout = &stdout
+	caddyDockerComposeCom.Stderr = &stderr
+
+	// Create certs directory if it doesn't exist
+	if _, err := os.Stat(caddyCertsDir); os.IsNotExist(err) {
+		if err := os.MkdirAll(caddyCertsDir, 0740); err != nil {
+			return fmt.Errorf("failed to create ingress certs directory: %w", err)
+		}
+	}
+
+	fmt.Println("Starting ingress proxy...")
+	if err := runCommandVerbose(caddyDockerComposeCom, verbose); err != nil {
+		// Combine stdout and stderr for complete output
+		fullOutput := stdout.String() + stderr.String()
+		return fmt.Errorf("failed to start ingress:\nError: %v\nOutput:\n%s", err, fullOutput)
+	}
+
+	// wait 5s to make sure Caddy is up
+	time.Sleep(5 * time.Second)
+	err = caddyapi.InitCaddy()
+	if err != nil {
+		panic(fmt.Errorf("failed to init ingress: %w", err))
+	}
+
+	fmt.Println("Ingress proxy started successfully!")
+	return nil
+} 

--- a/cmd/ingress/init.go
+++ b/cmd/ingress/init.go
@@ -15,7 +15,6 @@ import (
 )
 
 func newInitCmd() *cobra.Command {
-	var domain string
 	var verbose bool
 
 	cmd := &cobra.Command{
@@ -23,17 +22,14 @@ func newInitCmd() *cobra.Command {
 		Short: "Initializes an ingress proxy",
 		Args:  cobra.NoArgs,
 		RunE: func(cmd *cobra.Command, args []string) error {
-			if err := InitIngress(domain, verbose); err != nil {
+			if err := InitIngress(verbose); err != nil {
 				return fmt.Errorf("failed to initialize ingress: %w", err)
 			}
 			return nil
 		},
 	}
 
-	cmd.Flags().StringVar(&domain, "domain", "", "The domain to use for the ingress configuration")
 	cmd.Flags().BoolVarP(&verbose, "verbose", "v", false, "Enable verbose output")
-
-	cmd.MarkFlagRequired("domain")
 
 	return cmd
 }
@@ -106,7 +102,7 @@ func runCommandVerbose(cmd *exec.Cmd, verbose bool) error {
 	}
 }
 
-func InitIngress(domain string, verbose bool) error {
+func InitIngress(verbose bool) error {
 	bitswanConfig := os.Getenv("HOME") + "/.config/bitswan/"
 	caddyConfig := bitswanConfig + "caddy"
 	caddyCertsDir := caddyConfig + "/certs"
@@ -128,7 +124,7 @@ func InitIngress(domain string, verbose bool) error {
 		panic(fmt.Errorf("failed to write Caddyfile: %w", err))
 	}
 
-	caddyDockerCompose, err := dockercompose.CreateCaddyDockerComposeFile(caddyConfig, domain)
+	caddyDockerCompose, err := dockercompose.CreateCaddyDockerComposeFile(caddyConfig)
 	if err != nil {
 		panic(fmt.Errorf("failed to create ingress docker-compose file: %w", err))
 	}

--- a/cmd/ingress/list_routes.go
+++ b/cmd/ingress/list_routes.go
@@ -1,0 +1,68 @@
+package ingress
+
+import (
+	"fmt"
+
+	"github.com/bitswan-space/bitswan-workspaces/internal/caddyapi"
+	"github.com/spf13/cobra"
+)
+
+func newListRoutesCmd() *cobra.Command {
+	cmd := &cobra.Command{
+		Use:   "list-routes",
+		Short: "List all configured routes",
+		Long: `List all routes currently configured in the ingress proxy.
+
+Examples:
+  bitswan ingress list-routes`,
+		Args: cobra.NoArgs,
+		RunE: func(cmd *cobra.Command, args []string) error {
+			routes, err := caddyapi.ListRoutes()
+			if err != nil {
+				return fmt.Errorf("failed to list routes: %w", err)
+			}
+
+			if len(routes) == 0 {
+				fmt.Println("No routes configured")
+				return nil
+			}
+
+			fmt.Printf("Found %d route(s):\n\n", len(routes))
+			for _, route := range routes {
+				// Extract hostname from route match
+				var hostnames []string
+				for _, match := range route.Match {
+					hostnames = append(hostnames, match.Host...)
+				}
+
+				// Extract upstream from route handle
+				var upstreams []string
+				for _, handle := range route.Handle {
+					if handle.Handler == "subroute" {
+						for _, subRoute := range handle.Routes {
+							for _, subHandle := range subRoute.Handle {
+								if subHandle.Handler == "reverse_proxy" {
+									for _, upstream := range subHandle.Upstreams {
+										upstreams = append(upstreams, upstream.Dial)
+									}
+								}
+							}
+						}
+					}
+				}
+
+				// Display route information
+				if len(hostnames) > 0 && len(upstreams) > 0 {
+					fmt.Printf("Route ID: %s\n", route.ID)
+					fmt.Printf("  Hostname: %s\n", hostnames[0])
+					fmt.Printf("  Upstream: %s\n", upstreams[0])
+					fmt.Printf("  Terminal: %t\n\n", route.Terminal)
+				}
+			}
+
+			return nil
+		},
+	}
+
+	return cmd
+} 

--- a/cmd/ingress/remove_route.go
+++ b/cmd/ingress/remove_route.go
@@ -1,0 +1,31 @@
+package ingress
+
+import (
+	"fmt"
+
+	"github.com/bitswan-space/bitswan-workspaces/internal/caddyapi"
+	"github.com/spf13/cobra"
+)
+
+func newRemoveRouteCmd() *cobra.Command {
+	cmd := &cobra.Command{
+		Use:   "remove-route <hostname>",
+		Short: "Remove a route by hostname",
+		Long: `Remove a route that was previously configured for the specified hostname.
+
+Examples:
+  bitswan ingress remove-route foo.bar.example.com
+  bitswan ingress remove-route api.myapp.com`,
+		Args: cobra.ExactArgs(1),
+		RunE: func(cmd *cobra.Command, args []string) error {
+			hostname := args[0]
+
+			if err := caddyapi.RemoveRoute(hostname); err != nil {
+				return fmt.Errorf("failed to remove route: %w", err)
+			}
+			return nil
+		},
+	}
+
+	return cmd
+} 

--- a/cmd/ingress/root.go
+++ b/cmd/ingress/root.go
@@ -12,6 +12,8 @@ func NewIngressCmd() *cobra.Command {
 	}
 
 	cmd.AddCommand(newInitCmd())
+	cmd.AddCommand(newAddRouteCmd())
+	cmd.AddCommand(newRemoveRouteCmd())
 
 	return cmd
 } 

--- a/cmd/ingress/root.go
+++ b/cmd/ingress/root.go
@@ -1,0 +1,17 @@
+package ingress
+
+import "github.com/spf13/cobra"
+
+func NewIngressCmd() *cobra.Command {
+	cmd := &cobra.Command{
+		Use:   "ingress",
+		Short: "Manage ingress",
+		RunE: func(cmd *cobra.Command, args []string) error {
+			return cmd.Help()
+		},
+	}
+
+	cmd.AddCommand(newInitCmd())
+
+	return cmd
+} 

--- a/cmd/ingress/root.go
+++ b/cmd/ingress/root.go
@@ -14,6 +14,7 @@ func NewIngressCmd() *cobra.Command {
 	cmd.AddCommand(newInitCmd())
 	cmd.AddCommand(newAddRouteCmd())
 	cmd.AddCommand(newRemoveRouteCmd())
+	cmd.AddCommand(newListRoutesCmd())
 
 	return cmd
 } 

--- a/cmd/init.go
+++ b/cmd/init.go
@@ -18,7 +18,7 @@ import (
 
 	"gopkg.in/yaml.v3"
 
-	"github.com/bitswan-space/bitswan-workspaces/cmd/caddy"
+	"github.com/bitswan-space/bitswan-workspaces/cmd/ingress"
 	"github.com/bitswan-space/bitswan-workspaces/internal/caddyapi"
 	"github.com/bitswan-space/bitswan-workspaces/internal/dockercompose"
 	"github.com/bitswan-space/bitswan-workspaces/internal/dockerhub"
@@ -441,7 +441,7 @@ func (o *initOptions) run(cmd *cobra.Command, args []string) error {
 	}
 
 	if !caddy_running {
-		err = caddy.InitCaddy(o.domain, o.verbose)
+		err = ingress.InitIngress(o.domain, o.verbose)
 		if err != nil {
 			return fmt.Errorf("failed to initialize Caddy: %w", err)
 		}

--- a/cmd/init.go
+++ b/cmd/init.go
@@ -441,7 +441,7 @@ func (o *initOptions) run(cmd *cobra.Command, args []string) error {
 	}
 
 	if !caddy_running {
-		err = ingress.InitIngress(o.domain, o.verbose)
+		err = ingress.InitIngress(o.verbose)
 		if err != nil {
 			return fmt.Errorf("failed to initialize Caddy: %w", err)
 		}

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -9,6 +9,7 @@ import (
 
 	"github.com/bitswan-space/bitswan-workspaces/cmd/automation"
 	"github.com/bitswan-space/bitswan-workspaces/cmd/caddy"
+	"github.com/bitswan-space/bitswan-workspaces/cmd/ingress"
 	"github.com/spf13/cobra"
 )
 
@@ -24,7 +25,8 @@ func newRootCmd(version string) *cobra.Command {
 	cmd.AddCommand(newVersionCmd(version)) // version subcommand
 	cmd.AddCommand(newWorkspaceCmd())      // workspace subcommand
 	cmd.AddCommand(newRegisterCmd())       // register subcommand
-	cmd.AddCommand(caddy.NewCaddyCmd())    // caddy subcommand
+	cmd.AddCommand(ingress.NewIngressCmd()) // ingress subcommand
+	cmd.AddCommand(caddy.NewCaddyCmd())    // caddy subcommand (deprecated)
 
 	// Check if the configuration file exists and has an active workspace
 	configPath := filepath.Join(os.Getenv("HOME"), ".config", "bitswan", "config.toml")

--- a/internal/caddyapi/caddyapi.go
+++ b/internal/caddyapi/caddyapi.go
@@ -293,6 +293,23 @@ func RemoveRoute(hostname string) error {
 	return nil
 }
 
+// ListRoutes retrieves and lists all current routes from Caddy
+func ListRoutes() ([]Route, error) {
+	url := "http://localhost:2019/config/apps/http/servers/srv0/routes"
+	
+	responseBody, err := sendRequest("GET", url, nil)
+	if err != nil {
+		return nil, fmt.Errorf("failed to get routes from Caddy API: %w", err)
+	}
+	
+	var routes []Route
+	if err := json.Unmarshal(responseBody, &routes); err != nil {
+		return nil, fmt.Errorf("failed to parse routes response: %w", err)
+	}
+	
+	return routes, nil
+}
+
 func sendRequest(method, url string, payload []byte) ([]byte, error) {
 	client := &http.Client{}
 
@@ -313,7 +330,7 @@ func sendRequest(method, url string, payload []byte) ([]byte, error) {
 		return nil, fmt.Errorf("Caddy API returned status code %d for DELETE request", resp.StatusCode)
 	}
 
-	if resp.StatusCode != http.StatusOK {
+	if resp.StatusCode < 200 || resp.StatusCode >= 300 {
 		return nil, fmt.Errorf("Caddy API returned status code %d", resp.StatusCode)
 	}
 

--- a/internal/caddyapi/caddyapi.go
+++ b/internal/caddyapi/caddyapi.go
@@ -6,6 +6,8 @@ import (
 	"fmt"
 	"io/ioutil"
 	"net/http"
+	"os"
+	"strings"
 )
 
 type Route struct {
@@ -51,63 +53,34 @@ type TLSFileLoad struct {
 }
 
 func RegisterServiceWithCaddy(serviceName, workspaceName, domain, upstream string) error {
-	caddyAPIRoutesBaseUrl := "http://localhost:2019/config/apps/http/servers/srv0/routes/..."
-
-	// Create the route for the service
-	route := Route{
-		ID: fmt.Sprintf("%s_%s", workspaceName, serviceName),
-		Match: []Match{
-			{
-				Host: []string{fmt.Sprintf("%s-%s.%s", workspaceName, serviceName, domain)},
-			},
-		},
-		Handle: []Handle{
-			{
-				Handler: "subroute",
-				Routes: []Route{
-					{
-						Handle: []Handle{
-							{
-								Handler: "reverse_proxy",
-								Upstreams: []Upstream{
-									{
-										Dial: upstream,
-									},
-								},
-							},
-						},
-					},
-				},
-			},
-		},
-		Terminal: true,
-	}
-
-	// Marshal the route into JSON
-	jsonPayload, err := json.Marshal([]Route{route})
-	if err != nil {
-		return fmt.Errorf("failed to marshal route payload: %w", err)
-	}
-
-	// Send the payload to the Caddy API
-	_, err = sendRequest("POST", caddyAPIRoutesBaseUrl, jsonPayload)
-	if err != nil {
-		return fmt.Errorf("failed to add %s route to Caddy: %w", serviceName, err)
-	}
-
-	return nil
+	// Construct the hostname using the existing pattern
+	hostname := fmt.Sprintf("%s-%s.%s", workspaceName, serviceName, domain)
+	
+	// Use the new AddRoute function
+	return AddRoute(hostname, upstream)
 }
 
-func UnregisterCaddyService(serviceName, workspaceName string) error {
-	// Construct the URL for the specific service
-	url := fmt.Sprintf("http://localhost:2019/id/%s_%s", workspaceName, serviceName)
-
-	// Send a DELETE request to the Caddy API
-	if _, err := sendRequest("DELETE", url, nil); err != nil {
-		return fmt.Errorf("failed to unregister Caddy service '%s': %w", serviceName, err)
+func UnregisterCaddyService(serviceName, workspaceName, domain string) error {
+	// First try the new approach using hostname if domain is provided
+	if domain != "" {
+		hostname := fmt.Sprintf("%s-%s.%s", workspaceName, serviceName, domain)
+		err := RemoveRoute(hostname)
+		if err == nil {
+			return nil
+		}
+		// If new approach fails, print warning and try old approach
+		fmt.Printf("Warning: failed to remove route using hostname %s, trying legacy format: %v\n", hostname, err)
 	}
-
-	fmt.Printf("Successfully unregistered Caddy service: %s\n", serviceName)
+	
+	// Fall back to old approach using the legacy ID format
+	legacyID := fmt.Sprintf("%s_%s", workspaceName, serviceName)
+	url := fmt.Sprintf("http://localhost:2019/id/%s", legacyID)
+	
+	if _, err := sendRequest("DELETE", url, nil); err != nil {
+		return fmt.Errorf("failed to unregister service '%s' using both new and legacy formats: %w", serviceName, err)
+	}
+	
+	fmt.Printf("Successfully unregistered service using legacy format: %s\n", serviceName)
 	return nil
 }
 
@@ -191,14 +164,132 @@ func InitCaddy() error {
 }
 
 func DeleteCaddyRecords(workspaceName string) error {
-	services := []string{"gitops", "editor", "tlspolicy", "tlscerts"}
-
-	for _, service := range services {
-		if err := UnregisterCaddyService(service, workspaceName); err != nil {
-			return fmt.Errorf("failed to delete Caddy records for service '%s': %w", service, err)
+	// First, try to get the domain from workspace metadata
+	// We need to import the config package for this to work
+	// For now, we'll handle this differently by checking if we can delete by service routes first
+	
+	// Try to delete service routes (gitops, editor) by constructing likely hostnames
+	// We'll use a more robust approach by deleting directly by the old ID format for TLS items
+	
+	// Delete service routes that follow hostname pattern
+	serviceRoutes := []string{"gitops", "editor"}
+	
+	// For service routes, we need the domain. Let's try to get it from metadata
+	metadataPath := os.Getenv("HOME") + "/.config/bitswan/workspaces/" + workspaceName + "/metadata.yaml"
+	
+	// Read domain from metadata if available
+	var domain string
+	if data, err := os.ReadFile(metadataPath); err == nil {
+		// Simple YAML parsing to extract domain
+		lines := strings.Split(string(data), "\n")
+		for _, line := range lines {
+			if strings.HasPrefix(strings.TrimSpace(line), "domain:") {
+				parts := strings.Split(line, ":")
+				if len(parts) >= 2 {
+					domain = strings.TrimSpace(strings.Join(parts[1:], ":"))
+					domain = strings.Trim(domain, `"'`) // Remove quotes if present
+					break
+				}
+			}
 		}
 	}
+	
+	// Delete service routes if we have a domain
+	if domain != "" {
+		for _, service := range serviceRoutes {
+			hostname := fmt.Sprintf("%s-%s.%s", workspaceName, service, domain)
+			if err := RemoveRoute(hostname); err != nil {
+				// Don't fail completely if one service route fails - it might not exist
+				fmt.Printf("Warning: failed to remove route for %s: %v\n", hostname, err)
+			}
+		}
+	}
+	
+	// Delete TLS-related items using the old direct ID approach
+	tlsItems := []string{"tlspolicy", "tlscerts"}
+	for _, item := range tlsItems {
+		url := fmt.Sprintf("http://localhost:2019/id/%s_%s", workspaceName, item)
+		if _, err := sendRequest("DELETE", url, nil); err != nil {
+			// Don't fail completely if TLS items fail - they might not exist
+			fmt.Printf("Warning: failed to delete %s: %v\n", item, err)
+		}
+	}
+	
+	return nil
+}
 
+// sanitizeHostname converts a hostname to a safe ID by replacing dots and special chars with underscores
+func sanitizeHostname(hostname string) string {
+	return strings.ReplaceAll(strings.ReplaceAll(hostname, ".", "_"), "-", "_")
+}
+
+// AddRoute adds a generic route for any hostname to upstream mapping
+func AddRoute(hostname, upstream string) error {
+	caddyAPIRoutesBaseUrl := "http://localhost:2019/config/apps/http/servers/srv0/routes/..."
+
+	// Create a sanitized ID for the route based on hostname
+	routeID := sanitizeHostname(hostname)
+
+	// Create the route for the hostname
+	route := Route{
+		ID: routeID,
+		Match: []Match{
+			{
+				Host: []string{hostname},
+			},
+		},
+		Handle: []Handle{
+			{
+				Handler: "subroute",
+				Routes: []Route{
+					{
+						Handle: []Handle{
+							{
+								Handler: "reverse_proxy",
+								Upstreams: []Upstream{
+									{
+										Dial: upstream,
+									},
+								},
+							},
+						},
+					},
+				},
+			},
+		},
+		Terminal: true,
+	}
+
+	// Marshal the route into JSON
+	jsonPayload, err := json.Marshal([]Route{route})
+	if err != nil {
+		return fmt.Errorf("failed to marshal route payload: %w", err)
+	}
+
+	// Send the payload to the Caddy API
+	_, err = sendRequest("POST", caddyAPIRoutesBaseUrl, jsonPayload)
+	if err != nil {
+		return fmt.Errorf("failed to add route for %s to Caddy: %w", hostname, err)
+	}
+
+	fmt.Printf("Successfully added route: %s -> %s\n", hostname, upstream)
+	return nil
+}
+
+// RemoveRoute removes a route by hostname
+func RemoveRoute(hostname string) error {
+	// Create a sanitized ID for the route based on hostname
+	routeID := sanitizeHostname(hostname)
+	
+	// Construct the URL for the specific route
+	url := fmt.Sprintf("http://localhost:2019/id/%s", routeID)
+
+	// Send a DELETE request to the Caddy API
+	if _, err := sendRequest("DELETE", url, nil); err != nil {
+		return fmt.Errorf("failed to remove route for hostname '%s': %w", hostname, err)
+	}
+
+	fmt.Printf("Successfully removed route: %s\n", hostname)
 	return nil
 }
 

--- a/internal/caddyapi/caddyapi.go
+++ b/internal/caddyapi/caddyapi.go
@@ -8,6 +8,7 @@ import (
 	"net/http"
 	"os"
 	"strings"
+	"gopkg.in/yaml.v3"
 )
 
 type Route struct {
@@ -180,17 +181,14 @@ func DeleteCaddyRecords(workspaceName string) error {
 	// Read domain from metadata if available
 	var domain string
 	if data, err := os.ReadFile(metadataPath); err == nil {
-		// Simple YAML parsing to extract domain
-		lines := strings.Split(string(data), "\n")
-		for _, line := range lines {
-			if strings.HasPrefix(strings.TrimSpace(line), "domain:") {
-				parts := strings.Split(line, ":")
-				if len(parts) >= 2 {
-					domain = strings.TrimSpace(strings.Join(parts[1:], ":"))
-					domain = strings.Trim(domain, `"'`) // Remove quotes if present
-					break
-				}
-			}
+		// Parse YAML to extract domain using yaml.v3
+		var md struct {
+			Domain string `yaml:"domain"`
+		}
+		if err := yaml.Unmarshal(data, &md); err == nil {
+			domain = md.Domain
+		} else {
+			fmt.Printf("Warning: failed to parse %s: %v\n", metadataPath, err)
 		}
 	}
 	

--- a/internal/dockercompose/dockercompose.go
+++ b/internal/dockercompose/dockercompose.go
@@ -148,7 +148,7 @@ func CreateDockerComposeFile(gitopsPath, workspaceName, gitopsImage, bitswanEdit
 	return buf.String(), gitopsSecretToken, nil
 }
 
-func CreateCaddyDockerComposeFile(caddyPath, domain string) (string, error) {
+func CreateCaddyDockerComposeFile(caddyPath string) (string, error) {
 	caddyVolumes := []string{
 		caddyPath + "/Caddyfile:/etc/caddy/Caddyfile:z",
 		caddyPath + "/data:/data:z",


### PR DESCRIPTION
This refactor adds new commands for managing caddy routes.

```
[nix-shell:~/pu/bitswan/bitswan-automation-server/ingress-management1]$ ./bitswan ingress add-route foo.localhost dev-gitops-editor:9999
Successfully added route: foo.localhost -> dev-gitops-editor:9999

[nix-shell:~/pu/bitswan/bitswan-automation-server/ingress-management1]$ ./bitswan ingress list-routes
Found 43 route(s):
...
Route ID: foo_localhost
  Hostname: foo.localhost
  Upstream: dev-gitops-editor:9999
  Terminal: true

[nix-shell:~/pu/bitswan/bitswan-automation-server/ingress-management1]$ ./bitswan ingress remove-route foo.localhost
Successfully removed route: foo.localhost

[nix-shell:~/pu/bitswan/bitswan-automation-server/ingress-management1]$ ./bitswan ingress list-routes
Found 42 route(s):
...

```