### PR TITLE
feat: Add local mode support to Docker Compose file generation

### DIFF
--- a/cmd/init.go
+++ b/cmd/init.go
@@ -842,6 +842,7 @@ func (o *initOptions) run(cmd *cobra.Command, args []string) error {
 		aocEnvVars,
 		oauthConfig,
 		o.gitopsDevSourceDir,
+		o.local,
 	)
 
 	if err != nil {

--- a/cmd/update.go
+++ b/cmd/update.go
@@ -12,14 +12,15 @@ import (
 	"gopkg.in/yaml.v3"
 
 	"github.com/bitswan-space/bitswan-workspaces/internal/dockercompose"
-	"github.com/bitswan-space/bitswan-workspaces/internal/oauth"
 	"github.com/bitswan-space/bitswan-workspaces/internal/dockerhub"
+	"github.com/bitswan-space/bitswan-workspaces/internal/oauth"
 	"github.com/spf13/cobra"
 )
 
 type updateOptions struct {
 	gitopsImage string
 	editorImage string
+	local       bool
 }
 
 func newUpdateCmd() *cobra.Command {
@@ -43,6 +44,7 @@ func newUpdateCmd() *cobra.Command {
 
 	cmd.Flags().StringVar(&o.gitopsImage, "gitops-image", "", "Custom image for the gitops")
 	cmd.Flags().StringVar(&o.editorImage, "editor-image", "", "Custom image for the editor")
+	cmd.Flags().BoolVar(&o.local, "local", false, "Run the workspace in local mode")
 
 	return cmd
 }
@@ -154,15 +156,15 @@ func updateGitops(workspaceName string, o *updateOptions) error {
 	if err != nil {
 		return fmt.Errorf("failed to get OAuth config: %w", err)
 	}
-		
+
 	// Rewrite the docker-compose file
 	noIde := metadata.EditorURL == nil
 	var gitopsDevSourceDir string
 	if metadata.GitopsDevSourceDir != nil {
 		gitopsDevSourceDir = *metadata.GitopsDevSourceDir
 	}
-	compose, _, err := dockercompose.CreateDockerComposeFile(gitopsConfig, workspaceName, gitopsImage, bitswanEditorImage, metadata.Domain, noIde, mqttEnvVars, aocEnvVars, oauthConfig, gitopsDevSourceDir)
-  
+	compose, _, err := dockercompose.CreateDockerComposeFile(gitopsConfig, workspaceName, gitopsImage, bitswanEditorImage, metadata.Domain, noIde, mqttEnvVars, aocEnvVars, oauthConfig, gitopsDevSourceDir, o.local)
+
 	if err != nil {
 		panic(fmt.Errorf("failed to create docker-compose file: %w", err))
 	}

--- a/internal/dockercompose/dockercompose.go
+++ b/internal/dockercompose/dockercompose.go
@@ -25,7 +25,7 @@ const (
 )
 
 
-func CreateDockerComposeFile(gitopsPath, workspaceName, gitopsImage, bitswanEditorImage, domain string, noIde bool, mqttEnvVars []string, aocEnvVars []string, oauthConfig *oauth.Config, gitopsDevSourceDir string) (string, string, error) {
+func CreateDockerComposeFile(gitopsPath, workspaceName, gitopsImage, bitswanEditorImage, domain string, noIde bool, mqttEnvVars []string, aocEnvVars []string, oauthConfig *oauth.Config, gitopsDevSourceDir string, local bool) (string, string, error) {
 	sshDir := os.Getenv("HOME") + "/.ssh"
 	gitConfig := os.Getenv("HOME") + "/.gitconfig"
 
@@ -39,6 +39,11 @@ func CreateDockerComposeFile(gitopsPath, workspaceName, gitopsImage, bitswanEdit
 		hostOs = Linux
 	default:
 		return "", "", fmt.Errorf("unsupported host OS: %s", hostOsTmp)
+	}
+
+	jupyterServerEnableReverseProxy := "false"
+	if !local {
+		jupyterServerEnableReverseProxy = "true"
 	}
 
 	// generate a random secret token
@@ -61,6 +66,10 @@ func CreateDockerComposeFile(gitopsPath, workspaceName, gitopsImage, bitswanEdit
 			"BITSWAN_GITOPS_SECRET=" + gitopsSecretToken,
 			"BITSWAN_GITOPS_DOMAIN=" + domain,
 			"BITSWAN_WORKSPACE_NAME=" + workspaceName,
+			"JUPYTER_SERVER_ALLOWED_ORIGINS=http://localhost,http://127.0.0.1," + fmt.Sprintf("https://%s", domain),
+			"JUPYTER_SERVER_ENABLE_TOKEN_AUTH=true",
+			"JUPYTER_SERVER_DISABLE_XSRF_CHECK=false",
+			"JUPYTER_SERVER_ENABLE_REVERSE_PROXY=" + jupyterServerEnableReverseProxy,
 		},
 	}
 


### PR DESCRIPTION
- Introduce a new 'local' flag in the update command for running workspaces in local mode
- Update CreateDockerComposeFile function to accept the local parameter
- Adjust Jupyter server configuration based on the local mode setting